### PR TITLE
Deploy site: bio and research only

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,23 +12,39 @@
     <link rel="preconnect" href="https://api.semanticscholar.org">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="site.css" rel="stylesheet">
+    <link rel="icon" href="data:,">
     <style>
         section { padding: 88px 0; }
         section:nth-of-type(even) { background: var(--section-alt); }
 
+        /* Lab photo banner */
+        .lab-banner {
+            height: clamp(200px, 34vh, 340px);
+            overflow: hidden;
+        }
+        .lab-banner img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            object-position: center 45%;
+            display: block;
+        }
+
         /* Bio */
-        #bio { padding-top: 96px; min-height: 85vh; display: flex; align-items: center; }
+        #bio { padding-top: 72px; }
+        .bio-text ul { font-size: 0.9rem; color: var(--muted); }
 
         .bio-photo {
-            width: 190px;
-            height: 190px;
+            width: clamp(72px, 12vw, 150px);
+            height: clamp(72px, 12vw, 150px);
             border-radius: 50%;
             object-fit: cover;
             border: 2px solid var(--border);
+            flex-shrink: 0;
         }
 
         .bio-name {
-            font-size: clamp(2.2rem, 5vw, 3rem);
+            font-size: clamp(1.8rem, 4vw, 2.8rem);
             font-weight: 700;
             letter-spacing: -0.02em;
             margin-bottom: 0.2rem;
@@ -41,10 +57,21 @@
             margin-bottom: 1.2rem;
         }
 
+        .bio-link-inline {
+            color: inherit;
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 0.15s, color 0.15s;
+        }
+        .bio-link-inline:hover {
+            color: var(--accent);
+            border-bottom-color: var(--accent);
+        }
+
         .bio-text {
             font-size: 0.96rem;
             color: #333;
-            max-width: 580px;
+            max-width: 560px;
             margin-bottom: 1.5rem;
         }
 
@@ -67,37 +94,43 @@
         .bio-link.primary:hover { background: #144060; border-color: #144060; color: #fff; }
 
         /* Publications */
-        .pub-card {
-            background: var(--card-bg);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 1.1rem 1.35rem;
-            height: 100%;
-            transition: border-color 0.15s;
+        .pub-row {
+            display: flex;
+            align-items: flex-start;
+            gap: 1rem;
+            padding: 0.55rem 0;
+            border-bottom: 1px solid var(--border);
         }
-        .pub-card:hover { border-color: #b8b0a8; }
+        .pub-row:last-child { border-bottom: none; }
+        .pub-body { flex: 1; }
         .pub-title {
             font-family: 'Playfair Display', serif;
-            font-size: 0.92rem;
+            font-size: 0.875rem;
             font-weight: 600;
-            line-height: 1.4;
+            line-height: 1.35;
             color: var(--text);
-            margin-bottom: 0.3rem;
         }
-        .pub-venue   { font-size: 0.75rem; color: var(--accent); font-weight: 500; margin-bottom: 0.2rem; }
-        .pub-authors { font-size: 0.75rem; color: var(--muted); margin-bottom: 0.3rem; }
-        .pub-citations { font-size: 0.72rem; color: var(--muted); }
+        .pub-authors { font-size: 0.7rem; color: var(--muted); margin-top: 0.1rem; }
+        .pub-meta {
+            font-size: 0.7rem;
+            color: var(--muted);
+            white-space: nowrap;
+            flex-shrink: 0;
+            padding-top: 0.1rem;
+        }
         .pub-link {
-            display: inline-block;
-            margin-top: 0.5rem;
-            font-size: 0.72rem;
+            font-size: 0.7rem;
             font-weight: 500;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
             color: var(--accent);
             text-decoration: none;
             border: 1px solid var(--accent);
             border-radius: 2px;
-            padding: 2px 9px;
-            transition: background 0.15s, color 0.15s;
+            padding: 0.1rem 6px 1px;
+            white-space: nowrap;
+            flex-shrink: 0;
+            transition: background 0.12s, color 0.12s;
         }
         .pub-link:hover { background: var(--accent); color: #fff; }
 
@@ -106,14 +139,25 @@
         .course-meta { font-size: 0.75rem; color: var(--accent); font-weight: 500; margin-bottom: 0.25rem; }
         .course-desc { font-size: 0.83rem; color: var(--muted); margin: 0; }
 
-        /* Footer */
-        footer { background: #1c1c1c; color: #777; padding: 1.75rem 0; font-size: 0.78rem; text-align: center; }
-        footer a { color: #999; text-decoration: none; }
-        footer a:hover { color: #fff; }
+        /* Tools */
+        .tool-link { text-decoration: none; color: inherit; display: block; height: 100%; }
+        .tool-card {
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 1.35rem 1.5rem;
+            height: 100%;
+            transition: border-color 0.15s, box-shadow 0.15s;
+        }
+        .tool-card:hover { border-color: var(--accent); box-shadow: 0 4px 18px rgba(26,82,118,0.08); }
+        .tool-name { font-family: 'Playfair Display', serif; font-size: 1rem; font-weight: 600; margin-bottom: 0.2rem; }
+        .tool-tags { font-size: 0.7rem; color: var(--accent); font-weight: 500; letter-spacing: 0.04em; margin-bottom: 0.5rem; }
+        .tool-desc { font-size: 0.83rem; color: var(--muted); line-height: 1.6; }
+        .tool-cta  { font-size: 0.75rem; font-weight: 500; color: var(--accent); margin-top: 0.9rem; }
 
         @media (max-width: 767px) {
-            #bio { min-height: auto; padding-top: 72px; }
-            .bio-photo { width: 130px; height: 130px; }
+            .lab-banner { height: clamp(140px, 28vw, 220px); }
+            #bio { padding-top: 56px; }
             section { padding: 60px 0; }
         }
     </style>
@@ -130,31 +174,42 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="#bio">Bio</a></li>
                     <li class="nav-item"><a class="nav-link" href="#research">Research</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#teaching">Teaching</a></li>
                 </ul>
             </div>
         </div>
     </nav>
 
+    <!-- Lab photo banner -->
+    <div class="lab-banner">
+        <img src="https://lh3.googleusercontent.com/d/11s4arS68NSW7OsMRIs6lFLrq8ZZ98Mqu"
+             alt="Diffuse optics laboratory experiment"
+             onerror="this.parentElement.style.display='none'">
+    </div>
+
     <!-- Bio -->
     <section id="bio">
         <div class="container">
-            <div class="row align-items-center gx-5 gy-5">
-                <div class="col-md-3 text-center text-md-start">
-                    <img src="https://lh3.googleusercontent.com/d/1K9FCwAmBIO4cnpK-nn9NBMmOYHMrtJJC"
-                         alt="Giles Blaney"
-                         class="bio-photo"
-                         onerror="this.style.display='none'">
-                </div>
-                <div class="col-md-9">
-                    <div class="section-eyebrow">Postdoctoral Scholar</div>
+            <div class="d-flex align-items-center gap-4 gap-md-5">
+                <img src="https://lh3.googleusercontent.com/d/1K9FCwAmBIO4cnpK-nn9NBMmOYHMrtJJC"
+                     alt="Giles Blaney"
+                     class="bio-photo"
+                     onerror="this.style.display='none'">
+                <div>
+                    <div class="section-eyebrow">Postdoctoral Scholar · Tufts University</div>
                     <h1 class="bio-name">Giles Blaney, PhD</h1>
                     <p class="bio-subtitle">
-                        NIH Pathway to Independence Award · Diffuse Optical Imaging of Tissue Lab · Tufts University
+                        <a href="https://reporter.nih.gov/project-details/11215091" class="bio-link-inline" target="_blank" rel="noopener noreferrer">NIH Pathway to Independence Award</a> ·
+                        <a href="https://gsbs.tufts.edu/people/postdoc/giles-blaney" class="bio-link-inline" target="_blank" rel="noopener noreferrer">Tufts IRACDA</a><br>
+                        <a href="https://engineering.tufts.edu/bme/fantini/people" class="bio-link-inline" target="_blank" rel="noopener noreferrer">Diffuse Optical Imaging of Tissue Lab</a>
                     </p>
-                    <p class="bio-text">
-                        Researching diffuse optical techniques to detect physiological changes deeper within biological tissue, with focus on frequency-domain near-infrared spectroscopy and dual-slope methods. PhD from Tufts (Biomedical Engineering, 2022); B.S. from Northeastern (Mechanical Engineering &amp; Physics, 2017).
-                    </p>
+                    <div class="bio-text">
+                        <p>I research diffuse optical techniques with a focus on near-infrared spectroscopy and time-resolved methods.</p>
+                        <ul class="list-unstyled mb-0">
+                            <li><strong>PhD</strong>, Biomedical Engineering · Tufts University, 2022</li>
+                            <li><strong>BS</strong>, Mechanical Engineering &amp; Physics · Northeastern University, 2017<br>
+                                <small class="text-muted">(Minors: Electrical Engineering &amp; Mathematics)</small></li>
+                        </ul>
+                    </div>
                     <div class="bio-links">
                         <a href="mailto:Giles.Blaney@tufts.edu" class="bio-link primary">Email</a>
                         <a href="https://github.com/gblane" class="bio-link" target="_blank">GitHub</a>
@@ -173,36 +228,11 @@
             <div class="section-eyebrow">Publications</div>
             <h2>Research</h2>
             <hr class="section-rule">
-            <p class="mb-4" style="max-width:600px; color:var(--muted); font-size:0.93rem;">
+            <p class="section-intro">
                 Diffuse optical methods for physiological measurement in tissue: FD-NIRS, dual-slope imaging, and calibration-free spectroscopy. Sorted by citation count (h-index selection).
             </p>
-            <div id="publications" class="row g-3">
-                <div class="col-12" style="color:var(--muted)">Loading publications…</div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Teaching -->
-    <section id="teaching">
-        <div class="container">
-            <div class="section-eyebrow">Courses</div>
-            <h2>Teaching</h2>
-            <hr class="section-rule">
-            <div class="row g-3">
-                <div class="col-md-6">
-                    <div class="site-card">
-                        <div class="course-name">BME-0010 · Electrical Circuits and Biomedical Applications</div>
-                        <div class="course-meta">Tufts University · Fall 2023, 2024, 2025</div>
-                        <p class="course-desc">Required circuits course for biomedical engineers</p>
-                    </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="site-card">
-                        <div class="course-name">HONORS-295 · Radiation: Technology, Nature, and Society</div>
-                        <div class="course-meta">UMass Boston Honors College · Spring 2025</div>
-                        <p class="course-desc">Natural science general education course</p>
-                    </div>
-                </div>
+            <div id="publications">
+                <div style="color:var(--muted); font-size:0.88rem;">Loading publications…</div>
             </div>
         </div>
     </section>
@@ -215,7 +245,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        const esc = s => s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+        const esc = s => String(s ?? "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
 
         const CACHE_KEY = 'pubs_v1';
         const CACHE_TTL = 86400000;
@@ -242,8 +272,10 @@
                 const sorted = data.data.sort((a, b) => b.citationCount - a.citationCount);
                 const hIndex = sorted.reduce((h, p, i) => p.citationCount >= i + 1 ? i + 1 : h, 0);
                 container.innerHTML = sorted.slice(0, hIndex).map(p => {
-                    const authors = esc(p.authors.map(a => a.name).join(", "));
+                    const names = p.authors.map(a => esc(a.name));
+                    const authors = names.length > 3 ? names.slice(0, 3).join(", ") + " et al." : names.join(", ");
                     const venue = esc([p.venue, p.year].filter(Boolean).join(", "));
+                    const meta = [venue, `${p.citationCount} citation${p.citationCount !== 1 ? 's' : ''}`].filter(Boolean).join(" · ");
                     const pdfUrl = p.openAccessPdf?.url;
                     const doi = p.externalIds?.DOI;
                     const href = doi ? `https://doi.org/${doi}` : (pdfUrl || `https://www.semanticscholar.org/paper/${p.paperId}`);
@@ -252,22 +284,20 @@
                     const link = href
                         ? `<a href="${esc(href)}" class="pub-link" target="_blank">${esc(linkText)}</a>`
                         : "";
-                    return `
-                        <div class="col-md-6">
-                            <div class="pub-card">
-                                <div class="pub-title">${esc(p.title)}</div>
-                                <div class="pub-venue">${venue}</div>
-                                <div class="pub-authors">${authors}</div>
-                                <div class="pub-citations">${p.citationCount} citation${p.citationCount !== 1 ? 's' : ''}</div>
-                                ${link}
-                            </div>
-                        </div>`;
+                    return `<div class="pub-row">
+                        <div class="pub-body">
+                            <div class="pub-title">${esc(p.title)}</div>
+                            <div class="pub-authors">${authors}</div>
+                        </div>
+                        <span class="pub-meta">${meta}</span>
+                        ${link}
+                    </div>`;
                 }).join("");
             })
             .catch(err => {
                 console.error("Publications fetch failed:", err);
                 document.getElementById("publications").innerHTML =
-                    `<div class="col-12" style="color:var(--muted)">Unable to load publications. <a href="https://scholar.google.com/citations?user=zous0mAAAAAJ&hl=en" target="_blank" style="color:var(--accent)">View on Google Scholar</a>.</div>`;
+                    `<div style="color:var(--muted);font-size:0.88rem;">Unable to load publications. <a href="https://scholar.google.com/citations?user=zous0mAAAAAJ&hl=en" target="_blank" style="color:var(--accent)">View on Google Scholar</a>.</div>`;
             });
     </script>
 </body>

--- a/site.css
+++ b/site.css
@@ -52,13 +52,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .nav-link:hover,
-.nav-link.active {
-    color: var(--accent) !important;
-}
+.nav-link.active { color: var(--accent) !important; }
 
-.navbar-toggler {
-    border-color: var(--border);
-}
+.navbar-toggler { border-color: var(--border); }
 
 /* Dark hamburger icon for white navbar */
 .navbar-toggler-icon {
@@ -72,6 +68,11 @@ h1, h2, h3, h4, h5, h6 {
     border-radius: 6px;
     padding: 1.25rem 1.5rem;
     height: 100%;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.tool-link:hover .site-card {
+    border-color: var(--accent);
+    box-shadow: 0 4px 18px rgba(26,82,118,0.08);
 }
 
 /* ── Section helpers ──────────────────────────────── */
@@ -93,9 +94,85 @@ h1, h2, h3, h4, h5, h6 {
     margin: 14px 0 28px;
 }
 
+.section-intro {
+    max-width: 600px;
+    color: var(--muted);
+    font-size: 0.93rem;
+    margin-bottom: 1.5rem;
+}
+
+/* ── Course pages ─────────────────────────────────── */
+.course-hero {
+    padding: 88px 0 56px;
+    border-bottom: 1px solid var(--border);
+}
+
+.course-number {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 6px;
+}
+
+.course-title {
+    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.4rem;
+}
+
+.course-meta { font-size: 0.88rem; color: var(--muted); }
+.course-cta  { font-size: 0.75rem; font-weight: 500; color: var(--accent); margin-top: 0.9rem; }
+
+.material-section { padding: 52px 0; border-bottom: 1px solid var(--border); }
+.material-section:last-child { border-bottom: none; }
+
+.material-title { font-size: 1.1rem; font-weight: 600; margin-bottom: 1.25rem; }
+
+.mat-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.mat-row:last-child { border-bottom: none; }
+
+.mat-date {
+    font-size: 0.72rem;
+    color: var(--muted);
+    white-space: nowrap;
+    min-width: 3.5rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.mat-label { font-size: 0.88rem; color: var(--text); flex: 1; }
+
+.mat-sublabel { font-size: 0.78rem; color: var(--muted); display: block; margin-top: 0.1rem; }
+
+.mat-links { display: flex; gap: 0.4rem; flex-shrink: 0; }
+
+.mat-link {
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+    border: 1px solid var(--accent);
+    border-radius: 2px;
+    padding: 2px 7px;
+    transition: background 0.12s, color 0.12s;
+    white-space: nowrap;
+}
+.mat-link:hover { background: var(--accent); color: #fff; }
+
 /* ── Tool pages ───────────────────────────────────── */
-.tool-header { padding: 2rem 0 1.5rem; }
-.tool-title  { font-size: 2rem; font-weight: 700; margin-bottom: 0.15rem; }
+.tool-header   { padding: 2rem 0 1.5rem; }
+.tool-title    { font-size: 2rem; font-weight: 700; margin-bottom: 0.15rem; }
 .tool-subtitle { font-size: 0.88rem; color: var(--muted); }
 
 .param-card {
@@ -128,3 +205,8 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 1.55;
     margin: 0;
 }
+
+/* ── Footer ───────────────────────────────────────── */
+footer { background: #1c1c1c; color: #777; padding: 1.75rem 0; font-size: 0.78rem; text-align: center; }
+footer a { color: #999; text-decoration: none; }
+footer a:hover { color: #fff; }


### PR DESCRIPTION
## Summary

- Strips index.html to show only Bio and Research sections (removes Teaching, Tools, Dissertation nav links and page sections)
- Updates site.css and index.html from the `testing` branch to bring in the latest design: lab photo banner, responsive bio layout, inline pub-row publication list

## What's preserved

- Bio section (photo, name, links, credentials)
- Research section (Semantic Scholar publications, h-index selection, cached fetch)

## What's removed from the deployed page

- Teaching section and nav link
- Tools section and nav link
- Dissertation nav link

Continued development of those sections happens on the `testing` branch.

## Test plan

- [ ] Visit deployed site — only Bio and Research visible
- [ ] Navbar shows only "Bio" and "Research" links
- [ ] Publications load from Semantic Scholar API
- [ ] Lab banner photo renders
- [ ] Bio photo and links render

🤖 Generated with [Claude Code](https://claude.com/claude-code)