### PR TITLE
feat: add teaching section

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,6 +230,42 @@
         </div>
     </section>
 
+    <!-- Teaching -->
+    <section id="teaching">
+        <div class="container">
+            <div class="section-eyebrow">Lecturer</div>
+            <h2>Teaching</h2>
+            <hr class="section-rule">
+            <p class="section-intro">
+                Courses designed and taught as instructor of record.
+            </p>
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="tool-card">
+                        <div class="tool-name">Electrical Circuits and Biomedical Applications</div>
+                        <div class="tool-tags">Tufts University · Biomedical Engineering · BME-0010</div>
+                        <p class="tool-desc">Required course for biomedical engineers; syllabus designed de novo.</p>
+                        <div class="course-links">
+                            <a href="https://drive.google.com/file/d/1YcBnzSSY-OVjRyXwyR_fPdSj4Kt4YeRj/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Fa'23 ↗</a>
+                            <a href="https://drive.google.com/file/d/1NC7oc26wXdNZrydUwREMcDqzhEp9ck-U/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Fa'24 ↗</a>
+                            <a href="https://drive.google.com/file/d/19e8BC6r92iF6s7YWzvsWFmBOgTqE-RQQ/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Fa'25 ↗</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="tool-card">
+                        <div class="tool-name">Radiation: Technology, Nature, and Society</div>
+                        <div class="tool-tags">UMass Boston · Honors College · HONORS-295</div>
+                        <p class="tool-desc">Natural science general education course; developed de novo.</p>
+                        <div class="course-links">
+                            <a href="https://drive.google.com/file/d/1hMwxQQbhTBXROFUY9PwU549jStaYMLwR/view?usp=drive_link" target="_blank" rel="noopener noreferrer">Sp'25 ↗</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Tools -->
     <section id="tools">
         <div class="container">

--- a/index.html
+++ b/index.html
@@ -93,11 +93,6 @@
         .bio-link.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
         .bio-link.primary:hover { background: #144060; border-color: #144060; color: #fff; }
 
-        /* Teaching */
-        .course-name { font-family: 'Playfair Display', serif; font-size: 0.93rem; font-weight: 600; margin-bottom: 0.2rem; }
-        .course-meta { font-size: 0.75rem; color: var(--accent); font-weight: 500; margin-bottom: 0.25rem; }
-        .course-desc { font-size: 0.83rem; color: var(--muted); margin: 0; }
-
         /* Tools */
         .tool-link { text-decoration: none; color: inherit; display: block; height: 100%; }
         .tool-card {

--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@
         .tool-tags { font-size: 0.7rem; color: var(--accent); font-weight: 500; letter-spacing: 0.04em; margin-bottom: 0.5rem; }
         .tool-desc { font-size: 0.83rem; color: var(--muted); line-height: 1.6; }
         .tool-cta  { font-size: 0.75rem; font-weight: 500; color: var(--accent); margin-top: 0.9rem; }
+        .course-links { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 0.9rem; }
+        .course-links a { font-size: 0.75rem; font-weight: 500; color: var(--accent); text-decoration: none; }
+        .course-links a:hover { text-decoration: underline; }
 
 
         @media (max-width: 767px) {

--- a/index.html
+++ b/index.html
@@ -137,6 +137,7 @@
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item"><a class="nav-link" href="#bio">Bio</a></li>
                     <li class="nav-item"><a class="nav-link" href="#research">Research</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#teaching">Teaching</a></li>
                     <li class="nav-item"><a class="nav-link" href="#tools">Tools</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary

- Adds a Teaching section to `index.html` between Research and Tools
- Two course cards (BME-0010 at Tufts, HONORS-295 at UMass Boston) using the existing `.tool-card` design pattern
- Each card links to syllabi hosted on Google Drive (3 semesters for circuits, 1 for radiation)
- Teaching nav link added between Research and Tools
- Removes pre-existing orphaned `.course-name` / `.course-meta` / `.course-desc` CSS rules

## Test plan

- [x] Teaching link appears in navbar between Research and Tools
- [x] Clicking Teaching in nav scrolls to the section
- [x] Two cards appear side by side on desktop, stacked on mobile
- [x] All four syllabus links open the correct Google Drive PDFs in a new tab
- [x] Section background alternation looks correct across all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)